### PR TITLE
upgrade new dependencies on jenkins-common which now depends on jenki…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.synopsys.integration:jenkins-common:0.5.3'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.4'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 08 09:59:24 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 08 09:59:24 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jul 08 09:59:24 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
…ns 2.359 plus newer libraries

Update for jenkins annotation processor to consume new version of jenkins-common (upgraded to be based on jenkins 2.359)

This PR is dependent upon PR: https://github.com/synopsys-sig/jenkins-common/pull/34