### PR TITLE
Dev/jpp/master/annotation proc jenkins 2.359

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.synopsys.integration:jenkins-common:0.5.5-SNAPSHOT'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.5'
     implementation 'org.apache.commons:commons-text:1.10.0'
 
     implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,12 @@ repositories {
 dependencies {
     implementation 'com.synopsys.integration:jenkins-common:0.5.4'
     implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
+
+    implementation('com.vladsch.flexmark:flexmark-all:0.64.0') {
+        exclude group: 'com.ibm.icu', module: 'icu4j'
+    }
+
+    implementation 'com.ibm.icu:icu4j:71.1'
 
     testImplementation 'org.mockito:mockito-junit-jupiter:3.3.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.synopsys.integration:jenkins-common:0.5.4'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.5'
     implementation 'org.apache.commons:commons-text:1.10.0'
 
     implementation('com.vladsch.flexmark:flexmark-all:0.64.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.synopsys.integration:jenkins-common:0.5.5'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.5-SNAPSHOT'
     implementation 'org.apache.commons:commons-text:1.10.0'
 
-    implementation('com.vladsch.flexmark:flexmark-all:0.64.0') {
-        exclude group: 'com.ibm.icu', module: 'icu4j'
-    }
+    implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
 
+//  override icu4j as version pulled in by flexmark has issues.
     implementation 'com.ibm.icu:icu4j:71.1'
 
     testImplementation 'org.mockito:mockito-junit-jupiter:3.3.3'


### PR DESCRIPTION
Modified build.gradle to bump off icu4j 54.1 and pull in icu4j 71.1 hopefully mitigating critical security flaw.

Upstream PR: https://github.com/synopsys-sig/jenkins-common/pull/37
